### PR TITLE
Custom Blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,49 @@ Accepts: `boolea`
 Displays a checkbox for each node.
 Use in conjunction with `isChecked`.
 
+### Blocks
+
+You may optionally pass a block to both the `x-tree` and `x-tree-node`
+components to render nodes with custom HTML.
+
+```handlebars
+{{#x-tree model=branches as |nodes|}}
+  {{menu-children class='tree-node' model=nodes select=(action 'select') someProperty=7}}
+{{/x-tree}}
+
+{{!-- menu-children.hbs --}}
+
+{{menu-node model=model select=select hover=hover someProperty=7}}
+
+{{#if model.isExpanded}}
+  {{#x-tree model=model.children select=select hover=hover as |nodes|}}
+    {{menu-children model=nodes select=select hover=hover someProperty=7}}
+  {{/x-tree}}
+{{/if}}
+
+{{!-- menu-node.hbs --}}
+
+{{#x-tree-node model=model select=select}}
+  <span class="toggle-icon" {{action 'toggleExpand' bubbles=false}}>
+    {{#if model.children.length}}
+      {{#if model.isExpanded}}
+        &#x25BC;
+      {{else}}
+        &#x25B6;
+      {{/if}}
+    {{else}}
+      &nbsp;&nbsp;
+    {{/if}}
+  </span>
+
+  {{#if someProperty}}
+    <div>{{model.name}} has {{someProperty}}</div>
+  {{else}}
+    <div>{{model.name}}</div>
+  {{/if}}
+{{/x-tree-node}}
+```
+
 
 ### Model structure
 The component uses recursion to display the tree.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Fired when a node is selected.
 
 Default: `false`
 
-Accepts: `boolea`
+Accepts: `boolean`
 
 ```handlebars
 {{x-tree model=tree checkable=true}}

--- a/addon/templates/components/x-tree-node.hbs
+++ b/addon/templates/components/x-tree-node.hbs
@@ -1,17 +1,21 @@
-{{#if model.checkable}}
-  <input type="checkbox" checked={{model.isChecked}}
-    onclick={{action 'toggleCheck' bubbles=false}}>
-{{/if}}
-<span class="toggle-icon" {{action 'toggleExpand' bubbles=false}}>
-  {{#if model.children.length}}
-    {{#if model.isExpanded}}
-      &#x25BC;
-    {{else}}
-      &#x25B6;
-    {{/if}}
-  {{else}}
-    &nbsp;&nbsp;
+{{#if hasBlock}}
+  {{yield}}
+{{else}}
+  {{#if model.checkable}}
+    <input type="checkbox" checked={{model.isChecked}}
+      onclick={{action 'toggleCheck' bubbles=false}}>
   {{/if}}
-</span>
+  <span class="toggle-icon" {{action 'toggleExpand' bubbles=false}}>
+    {{#if model.children.length}}
+      {{#if model.isExpanded}}
+        &#x25BC;
+      {{else}}
+        &#x25B6;
+      {{/if}}
+    {{else}}
+      &nbsp;&nbsp;
+    {{/if}}
+  </span>
 
-{{model.name}}
+  {{model.name}}
+{{/if}}

--- a/addon/templates/components/x-tree.hbs
+++ b/addon/templates/components/x-tree.hbs
@@ -1,5 +1,9 @@
 {{#each model as |child|}}
   {{#if child.isVisible}}
-    {{x-tree-children model=child select=select hover=hover}}
+    {{#if hasBlock}}
+      {{yield child}}
+    {{else}}
+      {{x-tree-children model=child select=select hover=hover}}
+    {{/if}}
   {{/if}}
 {{/each}}


### PR DESCRIPTION
This allows users to optionally pass in custom HTML for tree nodes. This is useful if you, for example, need to render an icon or with different colors depending on the model.

Users who do not wish to use custom rendering should not be affected -- the non-block form still works.