### PR TITLE
Changing block behavior (possibly breaking existing implementations) and adding default options for buildTree

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,45 +92,20 @@ Expands the tree to a given depth.
 
 ### Blocks
 
-You may optionally pass a block to both the `x-tree` and `x-tree-node`
-components to render nodes with custom HTML.
+You may optionally pass a block to the `x-tree` component to render each node area with custom HTML.
+The node area is the area directly to the right of each arrow (and possibly checkbox) in the tree.
+The Node yields back the model for each area so that you can use attributes dynamically.
 
 ```handlebars
-{{#x-tree model=branches as |nodes|}}
-  {{menu-children class='tree-node' model=nodes select=(action 'select') someProperty=7}}
+{{#x-tree
+  select=(action 'selectNode')
+  chosenId=selectedNode
+  checkable=isCheckable
+  expandDepth=2
+  model=model as |node|}}
+    <i class="fa text-muted {{if node.isExpanded 'fa-folder-open' 'fa-folder'}}">&zwnj;</i>
+    {{node.name}}
 {{/x-tree}}
-
-{{!-- menu-children.hbs --}}
-
-{{menu-node model=model select=select hover=hover someProperty=7}}
-
-{{#if model.isExpanded}}
-  {{#x-tree model=model.children select=select hover=hover as |nodes|}}
-    {{menu-children model=nodes select=select hover=hover someProperty=7}}
-  {{/x-tree}}
-{{/if}}
-
-{{!-- menu-node.hbs --}}
-
-{{#x-tree-node model=model select=select}}
-  <span class="toggle-icon" {{action 'toggleExpand' bubbles=false}}>
-    {{#if model.children.length}}
-      {{#if model.isExpanded}}
-        &#x25BC;
-      {{else}}
-        &#x25B6;
-      {{/if}}
-    {{else}}
-      &nbsp;&nbsp;
-    {{/if}}
-  </span>
-
-  {{#if someProperty}}
-    <div>{{model.name}} has {{someProperty}}</div>
-  {{else}}
-    <div>{{model.name}}</div>
-  {{/if}}
-{{/x-tree-node}}
 ```
 
 

--- a/addon/components/x-tree-node.js
+++ b/addon/components/x-tree-node.js
@@ -10,12 +10,6 @@ export default Component.extend({
     return this.get('model.id') === this.get('chosenId');
   }),
 
-  click() {
-    let select = this.get('select');
-    if (select) {
-      select(this.get('model'));
-    }
-  },
   mouseEnter() {
     this.set('model.isSelected', true);
     let hover = this.get('hover');
@@ -38,6 +32,12 @@ export default Component.extend({
 
     toggleExpand() {
       this.toggleProperty('model.isExpanded');
+    },
+    select() {
+      let select = this.get('select');
+      if (select) {
+        select(this.get('model'));
+      }
     }
   }
 });

--- a/addon/components/x-tree.js
+++ b/addon/components/x-tree.js
@@ -1,6 +1,6 @@
 import Component from '@ember/component';
 import layout from '../templates/components/x-tree';
-import { getDescendents, getAncestors, getParent } from '../utils/tree';
+import { getDescendents, getAncestors } from '../utils/tree';
 import { get, set }  from '@ember/object';
 
 export default Component.extend({

--- a/addon/styles/x-tree.css
+++ b/addon/styles/x-tree.css
@@ -34,3 +34,7 @@
 .tree-node .tree-chosen {
   font-weight: bold;
 }
+
+.tree-node input[type="checkbox"] {
+  vertical-align: text-bottom;
+}

--- a/addon/templates/components/x-tree-branch.hbs
+++ b/addon/templates/components/x-tree-branch.hbs
@@ -1,7 +1,15 @@
 {{#each model as |child|}}
   {{#if child.isVisible}}
     {{#if hasBlock}}
-      {{yield child}}
+      {{#x-tree-children
+        select=select
+        hover=hover
+        hoverOut=hoverOut
+        checkable=checkable
+        chosenId=chosenId
+        model=child as |node|}}
+        {{yield node}}
+      {{/x-tree-children}}
     {{else}}
       {{x-tree-children
         model=child

--- a/addon/templates/components/x-tree-children.hbs
+++ b/addon/templates/components/x-tree-children.hbs
@@ -1,17 +1,41 @@
-{{x-tree-node
-  model=model
-  select=select
-  hover=hover
-  hoverOut=hoverOut
-  checkable=checkable
-  chosenId=chosenId}}
+{{#if hasBlock}}
+  {{#x-tree-node
+    select=select
+    hover=hover
+    hoverOut=hoverOut
+    checkable=checkable
+    chosenId=chosenId
+    model=model as |node|}}
+    {{yield node}}
+  {{/x-tree-node}}
 
-{{#if model.isExpanded}}
-  {{x-tree-branch
-    model=model.children
+  {{#if model.isExpanded}}
+    {{#x-tree-branch
+      select=select
+      hover=hover
+      hoverOut=hoverOut
+      checkable=checkable
+      chosenId=chosenId
+      model=model.children as |node|}}
+      {{yield node}}
+    {{/x-tree-branch}}
+  {{/if}}
+{{else}}
+  {{x-tree-node
+    model=model
     select=select
     hover=hover
     hoverOut=hoverOut
     checkable=checkable
     chosenId=chosenId}}
+
+  {{#if model.isExpanded}}
+    {{x-tree-branch
+      model=model.children
+      select=select
+      hover=hover
+      hoverOut=hoverOut
+      checkable=checkable
+      chosenId=chosenId}}
+  {{/if}}
 {{/if}}

--- a/addon/templates/components/x-tree-node.hbs
+++ b/addon/templates/components/x-tree-node.hbs
@@ -1,24 +1,25 @@
-{{#if hasBlock}}
-  {{yield}}
-{{else}}
-  {{#if checkable}}
-    <input type="checkbox" checked={{model.isChecked}}
-      onclick={{action 'toggleCheck' bubbles=false}}>
-  {{/if}}
-  <span class="toggle-icon" {{action 'toggleExpand' bubbles=false}}>
-    {{#if model.children.length}}
-      {{#if model.isExpanded}}
-        &#x25BC;
-      {{else}}
-        &#x25B6;
-      {{/if}}
+<span class="toggle-icon" {{action 'toggleExpand' bubbles=false}}>
+  {{#if model.children.length}}
+    {{#if model.isExpanded}}
+      &#x25BC;
     {{else}}
-      &nbsp;&nbsp;
+      &#x25B6;
     {{/if}}
-  </span>
-
-  {{#if model.treeIconClass}}
-    <i class="{{model.treeIconClass}}">&zwnj;</i>
+  {{else}}
+    &nbsp;&nbsp;
   {{/if}}
-  <span>{{model.name}}</span>
+</span>
+{{#if checkable}}
+  <input type="checkbox" checked={{model.isChecked}}
+    onclick={{action 'toggleCheck' bubbles=false}}>
+{{/if}}
+
+{{#if hasBlock}}
+  <span onclick={{action 'select'}}>
+    {{yield model}}
+  </span>
+{{else}}
+  <span onclick={{action 'select'}}>
+    {{model.name}}
+  </span>
 {{/if}}

--- a/addon/templates/components/x-tree.hbs
+++ b/addon/templates/components/x-tree.hbs
@@ -1,12 +1,12 @@
 {{#if hasBlock}}
   {{#x-tree-branch
-    model=model
     select=select
     hover=hover
     hoverOut=hoverOut
     checkable=checkable
-    chosenId=chosenId}}
-    {{yield}}
+    chosenId=chosenId
+    model=model as |node|}}
+    {{yield node}}
   {{/x-tree-branch}}
 {{else}}
   {{x-tree-branch

--- a/addon/utils/tree.js
+++ b/addon/utils/tree.js
@@ -9,7 +9,7 @@ import { isEmpty } from '@ember/utils';
  * passed for `id` and `labelKey` for `name`.
  * If the model is flat, it will return a list.
  */
-export function buildTree(model, options) {
+export function buildTree(model, options = {}) {
   let tree = {};
   let roots = A();
 


### PR DESCRIPTION
blocks now expose the content after the arrow/checkbox and yield back the model for each area, allowing complete customization of the name area.