### PR TITLE
Allow select when clicking outside of node text

### DIFF
--- a/addon/components/x-tree-node.js
+++ b/addon/components/x-tree-node.js
@@ -10,6 +10,13 @@ export default Component.extend({
     return this.get('model.id') === this.get('chosenId');
   }),
 
+  click() {
+    let select = this.get('select');
+    if (select) {
+      select(this.get('model'));
+    }
+  },
+
   mouseEnter() {
     this.set('model.isSelected', true);
     let hover = this.get('hover');
@@ -32,12 +39,6 @@ export default Component.extend({
 
     toggleExpand() {
       this.toggleProperty('model.isExpanded');
-    },
-    select() {
-      let select = this.get('select');
-      if (select) {
-        select(this.get('model'));
-      }
     }
   }
 });

--- a/addon/templates/components/x-tree-node.hbs
+++ b/addon/templates/components/x-tree-node.hbs
@@ -15,11 +15,7 @@
 {{/if}}
 
 {{#if hasBlock}}
-  <span onclick={{action 'select'}}>
-    {{yield model}}
-  </span>
+  {{yield model}}
 {{else}}
-  <span onclick={{action 'select'}}>
-    {{model.name}}
-  </span>
+  {{model.name}}
 {{/if}}


### PR DESCRIPTION
Recently (probably Ember 3) stopped calling the `select` action whenever clicking on a node outside of its
text (to the left or right of the node's name). This commit makes the entire x-tree-node clickable by adding
the `click()` handler. Checkboxes and expand arrows are not affected since they have `bubbles=false` set.