### PR TITLE
Fix event propagation on checkboxes

### DIFF
--- a/addon/components/x-tree-node.js
+++ b/addon/components/x-tree-node.js
@@ -33,10 +33,10 @@ export default Component.extend({
   },
 
   actions: {
-    toggleCheck() {
+    toggleCheck(event) {
+      event.stopPropagation();
       this.toggleProperty('model.isChecked');
     },
-
     toggleExpand() {
       this.toggleProperty('model.isExpanded');
     }

--- a/addon/templates/components/x-tree-node.hbs
+++ b/addon/templates/components/x-tree-node.hbs
@@ -10,8 +10,7 @@
   {{/if}}
 </span>
 {{#if checkable}}
-  <input type="checkbox" checked={{model.isChecked}}
-    onclick={{action 'toggleCheck' bubbles=false}}>
+  <input type="checkbox" checked={{model.isChecked}} onclick={{action 'toggleCheck'}}>
 {{/if}}
 
 {{#if hasBlock}}


### PR DESCRIPTION
The checkbox is using a js event while the containing div is using an ember event.  An explicit call to stopPropagation() must be used to prevent bubbling to the containing div when clicking on the checkbox.

more here: https://medium.com/square-corner-blog/deep-dive-on-ember-events-cf684fd3b808