### PR TITLE
adds syncing checkboxes to parents/children and display indeterminate…

### DIFF
--- a/addon/components/x-tree-node.js
+++ b/addon/components/x-tree-node.js
@@ -1,5 +1,5 @@
 import Component from '@ember/component';
-import { computed }  from '@ember/object';
+import { computed, observer }  from '@ember/object';
 import layout from '../templates/components/x-tree-node';
 
 export default Component.extend({
@@ -9,6 +9,30 @@ export default Component.extend({
   isChosen: computed('model.id', 'chosenId', function() {
     return this.get('model.id') === this.get('chosenId');
   }),
+
+  syncCheckbox: false,
+
+  __childrenCheckboxObserver: observer('model.children.@each.isChecked', function() {
+    if (this.get('syncCheckbox')) {
+      const children = this.get('model.children');
+      const allChildrenAreChecked = children.every(this._isChecked);
+      const someChildrenAreChecked = children.some(this._isChecked);
+      if (someChildrenAreChecked && !allChildrenAreChecked) {
+        this.set('model.isChecked', true);
+        this.set('model.isIndeterminate', true);
+      } else if (someChildrenAreChecked) {
+        this.set('model.isChecked', true);
+        this.set('model.isIndeterminate', false);
+      } else {
+        this.set('model.isChecked', false);
+        this.set('model.isIndeterminate', false);
+      }
+    }
+  }),
+
+  _isChecked(node) {
+    return node.isChecked;
+  },
 
   click() {
     let select = this.get('select');
@@ -32,10 +56,24 @@ export default Component.extend({
     }
   },
 
+  setChildCheckboxesRecursively(parentNode, checkValue) {
+    const children = parentNode.children;
+    if (children.length) {
+      children.setEach('isChecked', checkValue);
+      children.forEach((child) => {
+        this.setChildCheckboxesRecursively(child, checkValue);
+      });
+    }
+  },
+
   actions: {
     toggleCheck(event) {
       event.stopPropagation();
       this.toggleProperty('model.isChecked');
+      if (this.get('syncCheckbox')) {
+        const checkValue = this.get('model.isChecked');
+        this.setChildCheckboxesRecursively(this.get('model'), checkValue);
+      }
     },
     toggleExpand() {
       this.toggleProperty('model.isExpanded');

--- a/addon/templates/components/x-tree-branch.hbs
+++ b/addon/templates/components/x-tree-branch.hbs
@@ -6,6 +6,7 @@
         hover=hover
         hoverOut=hoverOut
         checkable=checkable
+        syncCheckbox=syncCheckbox
         chosenId=chosenId
         model=child as |node|}}
         {{yield node}}
@@ -17,6 +18,7 @@
         hover=hover
         hoverOut=hoverOut
         checkable=checkable
+        syncCheckbox=syncCheckbox
         chosenId=chosenId}}
     {{/if}}
   {{/if}}

--- a/addon/templates/components/x-tree-children.hbs
+++ b/addon/templates/components/x-tree-children.hbs
@@ -4,6 +4,7 @@
     hover=hover
     hoverOut=hoverOut
     checkable=checkable
+    syncCheckbox=syncCheckbox
     chosenId=chosenId
     model=model as |node|}}
     {{yield node}}
@@ -15,6 +16,7 @@
       hover=hover
       hoverOut=hoverOut
       checkable=checkable
+      syncCheckbox=syncCheckbox
       chosenId=chosenId
       model=model.children as |node|}}
       {{yield node}}
@@ -27,6 +29,7 @@
     hover=hover
     hoverOut=hoverOut
     checkable=checkable
+    syncCheckbox=syncCheckbox
     chosenId=chosenId}}
 
   {{#if model.isExpanded}}
@@ -36,6 +39,7 @@
       hover=hover
       hoverOut=hoverOut
       checkable=checkable
+      syncCheckbox=syncCheckbox
       chosenId=chosenId}}
   {{/if}}
 {{/if}}

--- a/addon/templates/components/x-tree-node.hbs
+++ b/addon/templates/components/x-tree-node.hbs
@@ -10,11 +10,16 @@
   {{/if}}
 </span>
 {{#if checkable}}
-  <input type="checkbox" checked={{model.isChecked}} onclick={{action 'toggleCheck'}}>
+  {{input type="checkbox"
+    checked=model.isChecked
+    change=(action 'toggleCheck')
+    indeterminate=model.isIndeterminate}}
 {{/if}}
 
-{{#if hasBlock}}
-  {{yield model}}
-{{else}}
-  {{model.name}}
-{{/if}}
+<span onclick={{action 'toggleCheck'}}>
+  {{#if hasBlock}}
+    {{yield model}}
+  {{else}}
+    {{model.name}}
+  {{/if}}
+</span>

--- a/addon/templates/components/x-tree.hbs
+++ b/addon/templates/components/x-tree.hbs
@@ -4,6 +4,7 @@
     hover=hover
     hoverOut=hoverOut
     checkable=checkable
+    syncCheckbox=syncCheckbox
     chosenId=chosenId
     model=model as |node|}}
     {{yield node}}
@@ -15,5 +16,6 @@
     hover=hover
     hoverOut=hoverOut
     checkable=checkable
+    syncCheckbox=syncCheckbox
     chosenId=chosenId}}
 {{/if}}


### PR DESCRIPTION
Reference to ticket: https://github.com/btecu/ember-simple-tree/issues/8

Hey - first of all, love the library! Really helpful for something I'm doing at work and figured I could do a PR to add some things I need. Looks like someone already made the request as well (ticket referenced above). I'm happy to also split this into separate commits as needed. Please let me know.

Changes include: 
-Checkbox propagates down to child nodes
-Checkbox propagates up to parent nodes through observer
-Checkbox is shown as indeterminate depending on child checkboxes (example below)
-Label is also clickable for checkboxes

State of checkboxes: 
![image](https://user-images.githubusercontent.com/15386324/43930617-50ef3c54-9bef-11e8-935c-e30299562c61.png)

