### PR TITLE
Add Recursive (syncing) Checkboxes

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,18 @@ Accepts: `number`
 Expands the tree to a given depth.
 `0` will not expand the tree at all, a negative number will fully expand a tree, a positive number will expand a tree to the given depth.
 
+#### recursiveCheck
+
+Default: `false`
+
+Accepts: `boolean`
+
+```handlebars
+{{x-tree model=tree checkable=true recursiveCheck=true}}
+```
+
+When enabled, checking a box will also check children's boxes as well. Also enables indeterminate state for checkboxes.
+Has no effect if `checkable` is not enabled.
 
 ### Blocks
 
@@ -128,8 +140,9 @@ The model requires specific properties to properly function:
  - `id` - unique identifier
  - `name` - `string` used to display a node
  - `children` - `array` of other nodes
- - `isChecked` - `boolean` used for a checkbox state
+ - `isChecked` - `boolean` used for checkbox state
  - `isExpanded` - `boolean` used to expand a node (children)
+ - `isIndeterminate` - `boolean` used for checkbox "indeterminate" display
  - `isSelected` - `boolean` optionally used for hover state
  - `isVisible` - `boolean` used to display or hide a node
 

--- a/addon/components/x-tree-children.js
+++ b/addon/components/x-tree-children.js
@@ -4,5 +4,35 @@ import layout from '../templates/components/x-tree-children';
 export default Component.extend({
   layout,
   tagName: 'li',
-  classNames: ['tree-node']
+  classNames: ['tree-node'],
+
+  actions: {
+    updateCheckbox() {
+      if (this.get('recursiveCheck')) {
+        let model = this.get('model');
+        let children = model.get('children');
+
+        if (children.length) {
+          if (children.every(x => x.isChecked)) {
+            model.setProperties({
+              isChecked: true,
+              isIndeterminate: false
+            });
+          } else if (children.some(x => x.isChecked || x.isIndeterminate)) {
+            model.setProperties({
+              isChecked: false,
+              isIndeterminate: true
+            });
+          } else {
+            model.setProperties({
+              isChecked: false,
+              isIndeterminate: false
+            });
+          }
+        }
+
+        this.sendAction('updateCheckbox');
+      }
+    }
+  }
 });

--- a/addon/components/x-tree-node.js
+++ b/addon/components/x-tree-node.js
@@ -1,5 +1,5 @@
 import Component from '@ember/component';
-import { computed }  from '@ember/object';
+import { computed, observer }  from '@ember/object';
 import layout from '../templates/components/x-tree-node';
 
 export default Component.extend({
@@ -9,6 +9,30 @@ export default Component.extend({
   isChosen: computed('model.id', 'chosenId', function() {
     return this.get('model.id') === this.get('chosenId');
   }),
+
+  syncCheckbox: false,
+
+  __childrenCheckboxObserver: observer('model.children.@each.isChecked', function() {
+    if (this.get('syncCheckbox')) {
+      const children = this.get('model.children');
+      const allChildrenAreChecked = children.every(this._isChecked);
+      const someChildrenAreChecked = children.some(this._isChecked);
+      if (someChildrenAreChecked && !allChildrenAreChecked) {
+        this.set('model.isChecked', true);
+        this.set('model.isIndeterminate', true);
+      } else if (someChildrenAreChecked) {
+        this.set('model.isChecked', true);
+        this.set('model.isIndeterminate', false);
+      } else {
+        this.set('model.isChecked', false);
+        this.set('model.isIndeterminate', false);
+      }
+    }
+  }),
+
+  _isChecked(node) {
+    return node.isChecked;
+  },
 
   click() {
     let select = this.get('onSelect');
@@ -33,11 +57,25 @@ export default Component.extend({
     }
   },
 
+  setChildCheckboxesRecursively(parentNode, checkValue) {
+    const children = parentNode.children;
+    if (children.length) {
+      children.setEach('isChecked', checkValue);
+      children.forEach((child) => {
+        this.setChildCheckboxesRecursively(child, checkValue);
+      });
+    }
+  },
+
   actions: {
     toggleCheck(event) {
       event.stopPropagation();
       this.toggleProperty('model.isChecked');
 
+      if (this.get('syncCheckbox')) {
+        const checkValue = this.get('model.isChecked');
+        this.setChildCheckboxesRecursively(this.get('model'), checkValue);
+      }
       let check = this.get('onCheck');
       if (check) {
         check(this.get('model'));

--- a/addon/components/x-tree.js
+++ b/addon/components/x-tree.js
@@ -5,6 +5,8 @@ import { get, set }  from '@ember/object';
 
 export default Component.extend({
   layout,
+  expandDepth: 0,
+  recursiveCheck: false,
 
   init() {
     this._super(...arguments);

--- a/addon/templates/components/x-tree-branch.hbs
+++ b/addon/templates/components/x-tree-branch.hbs
@@ -3,7 +3,8 @@
     {{#if hasBlock}}
       {{#x-tree-children
          checkable=checkable
-         syncCheckbox=syncCheckbox
+         recursiveCheck=recursiveCheck
+         updateCheckbox=updateCheckbox
          chosenId=chosenId
          onCheck=onCheck
          onSelect=onSelect
@@ -16,7 +17,8 @@
       {{x-tree-children
         model=child
         checkable=checkable
-        syncCheckbox=syncCheckbox
+        recursiveCheck=recursiveCheck
+        updateCheckbox=updateCheckbox
         chosenId=chosenId
         onCheck=onCheck
         onSelect=onSelect

--- a/addon/templates/components/x-tree-branch.hbs
+++ b/addon/templates/components/x-tree-branch.hbs
@@ -2,19 +2,21 @@
   {{#if child.isVisible}}
     {{#if hasBlock}}
       {{#x-tree-children
-        checkable=checkable
-        chosenId=chosenId
-        onCheck=onCheck
-        onSelect=onSelect
-        onHover=onHover
-        onHoverOut=onHoverOut
-        model=child as |node|}}
+         checkable=checkable
+         syncCheckbox=syncCheckbox
+         chosenId=chosenId
+         onCheck=onCheck
+         onSelect=onSelect
+         onHover=onHover
+         onHoverOut=onHoverOut
+         model=child as |node|}}
         {{yield node}}
       {{/x-tree-children}}
     {{else}}
       {{x-tree-children
         model=child
         checkable=checkable
+        syncCheckbox=syncCheckbox
         chosenId=chosenId
         onCheck=onCheck
         onSelect=onSelect

--- a/addon/templates/components/x-tree-children.hbs
+++ b/addon/templates/components/x-tree-children.hbs
@@ -1,24 +1,26 @@
 {{#if hasBlock}}
   {{#x-tree-node
-    checkable=checkable
-    chosenId=chosenId
-    onCheck=onCheck
-    onSelect=onSelect
-    onHover=onHover
-    onHoverOut=onHoverOut
-    model=model as |node|}}
+     checkable=checkable
+     syncCheckbox=syncCheckbox
+     chosenId=chosenId
+     onCheck=onCheck
+     onSelect=onSelect
+     onHover=onHover
+     onHoverOut=onHoverOut
+     model=model as |node|}}
     {{yield node}}
   {{/x-tree-node}}
 
   {{#if model.isExpanded}}
     {{#x-tree-branch
-      checkable=checkable
-      chosenId=chosenId
-      onCheck=onCheck
-      onSelect=onSelect
-      onHover=onHover
-      onHoverOut=onHoverOut
-      model=model.children as |node|}}
+       checkable=checkable
+       syncCheckbox=syncCheckbox
+       chosenId=chosenId
+       onCheck=onCheck
+       onSelect=onSelect
+       onHover=onHover
+       onHoverOut=onHoverOut
+       model=model.children as |node|}}
       {{yield node}}
     {{/x-tree-branch}}
   {{/if}}
@@ -26,6 +28,7 @@
   {{x-tree-node
     model=model
     checkable=checkable
+    syncCheckbox=syncCheckbox
     chosenId=chosenId
     onCheck=onCheck
     onSelect=onSelect
@@ -36,6 +39,7 @@
     {{x-tree-branch
       model=model.children
       checkable=checkable
+      syncCheckbox=syncCheckbox
       chosenId=chosenId
       onCheck=onCheck
       onSelect=onSelect

--- a/addon/templates/components/x-tree-children.hbs
+++ b/addon/templates/components/x-tree-children.hbs
@@ -1,7 +1,8 @@
 {{#if hasBlock}}
   {{#x-tree-node
      checkable=checkable
-     syncCheckbox=syncCheckbox
+     recursiveCheck=recursiveCheck
+     updateCheckbox=(action 'updateCheckbox')
      chosenId=chosenId
      onCheck=onCheck
      onSelect=onSelect
@@ -14,7 +15,8 @@
   {{#if model.isExpanded}}
     {{#x-tree-branch
        checkable=checkable
-       syncCheckbox=syncCheckbox
+       recursiveCheck=recursiveCheck
+       updateCheckbox=(action 'updateCheckbox')
        chosenId=chosenId
        onCheck=onCheck
        onSelect=onSelect
@@ -28,7 +30,8 @@
   {{x-tree-node
     model=model
     checkable=checkable
-    syncCheckbox=syncCheckbox
+    recursiveCheck=recursiveCheck
+    updateCheckbox=(action 'updateCheckbox')
     chosenId=chosenId
     onCheck=onCheck
     onSelect=onSelect
@@ -39,7 +42,8 @@
     {{x-tree-branch
       model=model.children
       checkable=checkable
-      syncCheckbox=syncCheckbox
+      recursiveCheck=recursiveCheck
+      updateCheckbox=(action 'updateCheckbox')
       chosenId=chosenId
       onCheck=onCheck
       onSelect=onSelect

--- a/addon/templates/components/x-tree-node.hbs
+++ b/addon/templates/components/x-tree-node.hbs
@@ -12,8 +12,8 @@
 {{#if checkable}}
   {{input type="checkbox"
     checked=model.isChecked
-    change=(action 'toggleCheck')
-    indeterminate=model.isIndeterminate}}
+    indeterminate=model.isIndeterminate
+    change=(action 'toggleCheck')}}
 {{/if}}
 
 <span onclick={{action 'toggleCheck'}}>

--- a/addon/templates/components/x-tree-node.hbs
+++ b/addon/templates/components/x-tree-node.hbs
@@ -10,11 +10,16 @@
   {{/if}}
 </span>
 {{#if checkable}}
-  <input type="checkbox" checked={{model.isChecked}} onclick={{action 'toggleCheck'}}>
+  {{input type="checkbox"
+    checked=model.isChecked
+    change=(action 'toggleCheck')
+    indeterminate=model.isIndeterminate}}
 {{/if}}
 
-{{#if hasBlock}}
-  {{yield model}}
-{{else}}
-  {{model.name}}
-{{/if}}
+<span onclick={{action 'toggleCheck'}}>
+  {{#if hasBlock}}
+    {{yield model}}
+  {{else}}
+    {{model.name}}
+  {{/if}}
+</span>

--- a/addon/templates/components/x-tree.hbs
+++ b/addon/templates/components/x-tree.hbs
@@ -1,7 +1,7 @@
 {{#if hasBlock}}
   {{#x-tree-branch
      checkable=checkable
-     syncCheckbox=syncCheckbox
+     recursiveCheck=recursiveCheck
      chosenId=chosenId
      onCheck=onCheck
      onSelect=onSelect
@@ -14,7 +14,7 @@
   {{x-tree-branch
     model=model
     checkable=checkable
-    syncCheckbox=syncCheckbox
+    recursiveCheck=recursiveCheck
     chosenId=chosenId
     onCheck=onCheck
     onSelect=onSelect

--- a/addon/templates/components/x-tree.hbs
+++ b/addon/templates/components/x-tree.hbs
@@ -1,18 +1,20 @@
 {{#if hasBlock}}
   {{#x-tree-branch
-    checkable=checkable
-    chosenId=chosenId
-    onCheck=onCheck
-    onSelect=onSelect
-    onHover=onHover
-    onHoverOut=onHoverOut
-    model=model as |node|}}
+     checkable=checkable
+     syncCheckbox=syncCheckbox
+     chosenId=chosenId
+     onCheck=onCheck
+     onSelect=onSelect
+     onHover=onHover
+     onHoverOut=onHoverOut
+     model=model as |node|}}
     {{yield node}}
   {{/x-tree-branch}}
 {{else}}
   {{x-tree-branch
     model=model
     checkable=checkable
+    syncCheckbox=syncCheckbox
     chosenId=chosenId
     onCheck=onCheck
     onSelect=onSelect


### PR DESCRIPTION
Since @teddycoleman does not have time to update his PR right now but I need this functionality now, I created this other PR to replace it.

By passing an option `recursiveCheck`, checkboxes will also update their children on change. I have tried to also make this logic work on selection of the label, such that if your select action handler toggles the checkbox, the same logic should be run. Additionally, enabling this flag also allows checkboxes to have an "indeterminate" state.

Most of this code was taken from the original in PR #10. I cleaned it up some to use a more consistent coding style, as well as remove the use of an observer.

Fixes #8. Closes #10.