### PR TITLE
extending onContextMenu to return the complete component element and the event

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Standard example:
 
 #### onCheck
 
-Returns: `node`
+Returns: `node.model`
 
 Fired when a checkbox state changes.
 
@@ -65,7 +65,7 @@ Fired on contextMenu event.
 
 #### onHover
 
-Returns: `node`
+Returns: `node.model`
 
 Fired when a mouse enters the node.
 
@@ -75,7 +75,7 @@ Fired when a mouse enters the node.
 
 #### onHoverOut
 
-Returns: `node`
+Returns: `node.model`
 
 Fired when a mouse leaves the node.
 
@@ -85,7 +85,7 @@ Fired when a mouse leaves the node.
 
 #### onSelect
 
-Returns: `node`
+Returns: `node.model`
 
 Fired when a node is selected.
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Fired when a checkbox state changes.
 
 #### onContextMenu
 
-Returns: `node`
+Returns: `node`, `event` 
 
 Fired on contextMenu event.
 

--- a/addon/components/x-tree-node.js
+++ b/addon/components/x-tree-node.js
@@ -35,7 +35,7 @@ export default Component.extend({
   contextMenu(event) {
     if (this.onContextMenu) {
       event.preventDefault();
-      this.onContextMenu(this.model);
+      this.onContextMenu(this, event);
     }
   },
 

--- a/tests/integration/components/x-tree-test.js
+++ b/tests/integration/components/x-tree-test.js
@@ -243,12 +243,16 @@ module('Integration | Component | x-tree', function(hooks) {
   });
 
   test('contextMenu event', async function(assert) {
-    this.set('onContextMenu', x => this.name = x.name);
+    this.set('onContextMenu', (x, event) => {
+      this.name = x.model.name;
+      this.targetTagName = event.target.tagName;
+    });
     this.set('tree', standardTree);
 
     await render(hbs`{{x-tree model=tree onContextMenu=onContextMenu}}`);
     await triggerEvent('.tree-node span', 'contextmenu')
 
     assert.equal(this.name, 'Root', 'item from contextMenu event is returned as expected');
+    assert.equal(this.targetTagName, 'SPAN', 'contextMenu event hit a span element');
   });
 });


### PR DESCRIPTION
(instead of just the model – useful for positioning context menus)

• not sure about the README changes to onCheck, onHover, onHoverOut, and onSelect in 7ec8923,   but it should be specified in the README that these functions return `this.model`, and onContextMenu returns the complete component element (`this`)