### PR TITLE
[do not merge yet] lazy render children

### DIFF
--- a/addon/components/x-tree-children.js
+++ b/addon/components/x-tree-children.js
@@ -1,11 +1,39 @@
 import Component from '@ember/component';
 import layout from '../templates/components/x-tree-children';
+import { later, run } from '@ember/runloop';
 import { setProperties } from '@ember/object';
 
 export default Component.extend({
   layout,
   tagName: 'li',
   classNames: ['tree-node'],
+
+  renderChildren: true, // private
+  lazyRenderChildren: false,
+  lazyRenderChildrenTimeout: 500,
+
+  init() {
+    this._super(...arguments);
+    if(this.lazyRenderChildren && this.model.nodeDepth > 0) {
+      this.toggleProperty('renderChildren');
+    }
+  },
+
+  didInsertElement() {
+    this._super(...arguments);
+    if(!this.renderChildren) {
+      run('afterRender', () => {
+        later(this, 'toggleRenderChildren', this.lazyRenderChildrenTimeout);
+      });
+    }
+  },
+
+  toggleRenderChildren() {
+    if (this.isDestroying || this.isDestroyed) {
+      return;
+    }
+    this.toggleProperty('renderChildren');
+  },
 
   actions: {
     updateCheckbox() {

--- a/addon/components/x-tree.js
+++ b/addon/components/x-tree.js
@@ -6,6 +6,7 @@ import { get, set }  from '@ember/object';
 export default Component.extend({
   layout,
   expandDepth: 0,
+  lazyRenderChildren: false,
   recursiveCheck: false,
   classNames: ['tree'],
 

--- a/addon/templates/components/x-tree-branch.hbs
+++ b/addon/templates/components/x-tree-branch.hbs
@@ -3,6 +3,7 @@
     {{#if hasBlock}}
       {{#x-tree-children
         checkable=checkable
+        lazyRenderChildren=lazyRenderChildren
         recursiveCheck=recursiveCheck
         updateCheckbox=updateCheckbox
         chosenId=chosenId
@@ -22,6 +23,7 @@
       {{x-tree-children
         model=child
         checkable=checkable
+        lazyRenderChildren=lazyRenderChildren
         recursiveCheck=recursiveCheck
         updateCheckbox=updateCheckbox
         chosenId=chosenId

--- a/addon/templates/components/x-tree-children.hbs
+++ b/addon/templates/components/x-tree-children.hbs
@@ -18,23 +18,26 @@
   {{/x-tree-node}}
 
   {{#if model.isExpanded}}
-    {{#x-tree-branch
-      checkable=checkable
-      recursiveCheck=recursiveCheck
-      updateCheckbox=(action "updateCheckbox")
-      chosenId=chosenId
-      onCheck=onCheck
-      onContextMenu=onContextMenu
-      onSelect=onSelect
-      onHover=onHover
-      onHoverOut=onHoverOut
-      model=model.children
-      expandedIcon=expandedIcon
-      collapsedIcon=collapsedIcon
-      as |node|
-    }}
-      {{yield node}}
-    {{/x-tree-branch}}
+    {{#if renderChildren}}
+      {{#x-tree-branch
+        checkable=checkable
+        lazyRenderChildren=lazyRenderChildren
+        recursiveCheck=recursiveCheck
+        updateCheckbox=(action "updateCheckbox")
+        chosenId=chosenId
+        onCheck=onCheck
+        onContextMenu=onContextMenu
+        onSelect=onSelect
+        onHover=onHover
+        onHoverOut=onHoverOut
+        model=model.children
+        expandedIcon=expandedIcon
+        collapsedIcon=collapsedIcon
+        as |node|
+      }}
+        {{yield node}}
+      {{/x-tree-branch}}
+    {{/if}}
   {{/if}}
 {{else}}
   {{x-tree-node
@@ -52,19 +55,22 @@
     collapsedIcon=collapsedIcon
   }}
   {{#if model.isExpanded}}
-    {{x-tree-branch
-      model=model.children
-      checkable=checkable
-      recursiveCheck=recursiveCheck
-      updateCheckbox=(action "updateCheckbox")
-      chosenId=chosenId
-      onCheck=onCheck
-      onContextMenu=onContextMenu
-      onSelect=onSelect
-      onHover=onHover
-      onHoverOut=onHoverOut
-      expandedIcon=expandedIcon
-      collapsedIcon=collapsedIcon
-    }}
+    {{#if renderChildren}}
+      {{x-tree-branch
+        model=model.children
+        checkable=checkable
+        lazyRenderChildren=lazyRenderChildren
+        recursiveCheck=recursiveCheck
+        updateCheckbox=(action "updateCheckbox")
+        chosenId=chosenId
+        onCheck=onCheck
+        onContextMenu=onContextMenu
+        onSelect=onSelect
+        onHover=onHover
+        onHoverOut=onHoverOut
+        expandedIcon=expandedIcon
+        collapsedIcon=collapsedIcon
+      }}
+    {{/if}}
   {{/if}}
 {{/if}}

--- a/addon/templates/components/x-tree.hbs
+++ b/addon/templates/components/x-tree.hbs
@@ -1,6 +1,7 @@
 {{#if hasBlock}}
   {{#x-tree-branch
     checkable=checkable
+    lazyRenderChildren=lazyRenderChildren
     recursiveCheck=recursiveCheck
     chosenId=chosenId
     onCheck=onCheck
@@ -19,6 +20,7 @@
   {{x-tree-branch
     model=model
     checkable=checkable
+    lazyRenderChildren=lazyRenderChildren
     recursiveCheck=recursiveCheck
     chosenId=chosenId
     onCheck=onCheck

--- a/addon/utils/tree.js
+++ b/addon/utils/tree.js
@@ -56,18 +56,20 @@ export function buildTree(model, options = {}) {
 }
 
 // Returns a flat list of all descenents, including the root
-export function getDescendents(tree, depth = -1) {
+export function getDescendents(tree, depth = -1, nodeDepth = 0) {
   let descendents = A();
 
   if (depth < 0) { // Unlimited depth
     tree.forEach(node => {
+      node.nodeDepth = nodeDepth;
       descendents.pushObject(node);
-      descendents.pushObjects(getDescendents(get(node, 'children')));
+      descendents.pushObjects(getDescendents(get(node, 'children'), -1, nodeDepth + 1));
     });
   } else if (depth > 0) {
     tree.forEach(node => {
+      node.nodeDepth = nodeDepth;
       descendents.pushObject(node);
-      descendents.pushObjects(getDescendents(get(node, 'children'), depth - 1));
+      descendents.pushObjects(getDescendents(get(node, 'children'), depth - 1, nodeDepth + 1));
     });
   }
 


### PR DESCRIPTION
@btecu , @Gaurav0

# Issue
- nested tree models render very slowly once they are deeper than 2 levels

> root-1
.... branch-1
........ leaf-1 (this level causes the component to block and render very slowly)
> root-2
> root-3
> etc...

# Implemented quick fix
- I added a lazy render to x-tree-children (really it's a delayed render)
- total render time still isn't great, but the first 2 levels are visible much faster rather than showing a blank section on screen for a long time
- good enough to merge?

# Other potential fixes
- use [ember-in-viewport](https://github.com/DockYard/ember-in-viewport) to only render what's visible
- switch to Glimmer components

# Data samples
- contains 3 different sample data files
- contains template example to generate different sized JSON files with [json-generator.com](https://www.json-generator.com/) 
[jsonSampleTreeDataFiles.zip](https://github.com/btecu/ember-simple-tree/files/5059355/jsonSampleTreeDataFiles.zip)
