### PR TITLE
Add @glimmer/component to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,13 +36,13 @@
   },
   "dependencies": {
     "ember-cli-babel": "^7.26.6",
-    "ember-cli-htmlbars": "^5.7.1"
+    "ember-cli-htmlbars": "^5.7.1",
+    "@glimmer/component": "^1.0.4",
   },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.2.6",
     "@embroider/test-setup": "^0.41.0",
-    "@glimmer/component": "^1.0.4",
     "@glimmer/tracking": "^1.0.4",
     "babel-eslint": "^10.1.0",
     "broccoli-asset-rev": "^3.0.0",


### PR DESCRIPTION
It needs to be either a dep or peer-dep now that it is in use.